### PR TITLE
Correct typos

### DIFF
--- a/test_partA.cpp
+++ b/test_partA.cpp
@@ -1,5 +1,5 @@
-#include "../part1/date_wrap.h"
-#include "../part1/exceptions.h"
+#include "../partA/date_wrap.h"
+#include "../partA/exceptions.h"
 #include <iostream>
 #include <fstream>
 using mtm::DateWrap;
@@ -7,7 +7,7 @@ using std::cout;
 using std::endl;
 using std::ifstream;
 using std::ofstream;
-using mtm::Exceptions;
+using mtm::Exception;
 
 #define ASSERT_TEST(expr)                                                         \
      do {                                                                          \

--- a/test_partB.cpp
+++ b/test_partB.cpp
@@ -1,13 +1,13 @@
-#include "../part2/base_event.h"
-#include "../part2/closed_event.h"
-#include "../part2/custom_event.h"
-#include "../part1/date_wrap.h"
-#include "../part2/event_container.h"
-#include "../part1/exceptions.h"
-#include "../part2/festival.h"
-#include "../part2/one_time_event.h"
-#include "../part2/open_event.h"
-#include "../part2/recurring_event.h"
+#include "../partB/base_event.h"
+#include "../partB/closed_event.h"
+#include "../partB/custom_event.h"
+#include "../partA/date_wrap.h"
+#include "../partB/event_container.h"
+#include "../partA/exceptions.h"
+#include "../partB/festival.h"
+#include "../partB/one_time_event.h"
+#include "../partB/open_event.h"
+#include "../partB/recurring_event.h"
 #include <cstdlib>
 #include <iostream>
 #include <fstream>
@@ -191,7 +191,7 @@ bool testConstructorOpenEvent()
 bool testRegisterParticipantOpenEvent()
 {
     bool result = true;
-   OPEN_FILE(out, "../../provided/testOutputs/partB/your_outputs/testRegisterParticipantOpenEvent.txt")
+    OPEN_FILE(out, "../../provided/testOutputs/partB/your_outputs/testRegisterParticipantOpenEvent.txt")
     try {
         OpenEvent event1(DateWrap(0, 1, 2000), "event1");
     }catch(mtm::InvalidDate&){

--- a/test_partC.cpp
+++ b/test_partC.cpp
@@ -1,14 +1,14 @@
-#include "base_event.h"
-#include "closed_event.h"
-#include "custom_event.h"
-#include "date_wrap.h"
-#include "event_container.h"
-#include "exceptions.h"
-#include "festival.h"
-#include "one_time_event.h"
-#include "open_event.h"
-#include "recurring_event.h"
-#include "schedule.h"
+#include "../partB/base_event.h"
+#include "../partB/closed_event.h"
+#include "../partB/custom_event.h"
+#include "../partA/date_wrap.h"
+#include "../partB/event_container.h"
+#include "../partA/exceptions.h"
+#include "../partB/festival.h"
+#include "../partB/one_time_event.h"
+#include "../partB/open_event.h"
+#include "../partB/recurring_event.h"
+#include "../partC/schedule.h"
 #include <cstdlib>
 #include <iostream>
 
@@ -22,7 +22,7 @@ void test3(const mtm::Schedule& schedule) {
     schedule.printEventDetails(mtm::DateWrap(5, 1, 2021), "Update Q&A");
 }
 
-void test4(const mtm::Schedule& schedule) { schedule.printMonthEvents(12); }
+void test4(const mtm::Schedule& schedule) { schedule.printMonthEvents(12, 2020); }
 
 class MutatingPredicate {
     int counter = 0;
@@ -44,7 +44,7 @@ const Test tests[] = {test1, test2, test3, test4, test5};
 int main(int argc, char* argv[]) {
     mtm::Schedule schedule;
     schedule.addEvents(mtm::OneTimeEvent<mtm::OpenEvent>(
-        mtm::DateWrap(27, 12, 2020), "Publish Test"));
+            mtm::DateWrap(27, 12, 2020), "Publish Test"));
 
     mtm::RecurringEvent<mtm::ClosedEvent> closed(mtm::DateWrap(20, 12, 2020),
                                                  "Update Q&A", 6, 5);


### PR DESCRIPTION
According to the Segel, the files should be in partA, partB, partC. An additional typo was fixed with relation to exception.h, and the part C test was fixed for consistency.
![image](https://user-images.githubusercontent.com/11412452/104643254-cee2bc80-56b4-11eb-9577-8142ce838852.png)
